### PR TITLE
Add parsing options to <Localize/> and className attribute to <Translate/> and <Localize/>

### DIFF
--- a/build/lib/I18n.js
+++ b/build/lib/I18n.js
@@ -130,8 +130,7 @@ exports.default = {
     var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     if (options.dateFormat) {
-      _moment2.default.locale(this._locale);
-      return (0, _moment2.default)(value).format(this.t(options.dateFormat));
+      return (0, _moment2.default)(value, options.parseFormat, this._locale, Boolean(options.strictParse)).format(this.t(options.dateFormat));
     }
     if (typeof value === 'number') {
       if (global.Intl) {

--- a/build/lib/Localize.js
+++ b/build/lib/Localize.js
@@ -50,7 +50,7 @@ var Localize = function (_BaseComponent) {
           style = _props.style,
           className = _props.className;
 
-      var localization = _I18n2.default._localize(value, _extends({ dateFormat: dateFormat }, options));
+      var localization = _I18n2.default._localize(value, _extends({}, options, { dateFormat: dateFormat }));
 
       if (dangerousHTML) {
         return _react2.default.createElement('span', { style: style, className: className, dangerouslySetInnerHTML: { __html: localization } });

--- a/build/lib/Localize.js
+++ b/build/lib/Localize.js
@@ -4,6 +4,10 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -29,28 +33,35 @@ var Localize = function (_BaseComponent) {
   _inherits(Localize, _BaseComponent);
 
   function Localize() {
-    var _ref;
-
-    var _temp, _this, _ret;
-
     _classCallCheck(this, Localize);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
+    return _possibleConstructorReturn(this, (Localize.__proto__ || Object.getPrototypeOf(Localize)).apply(this, arguments));
+  }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Localize.__proto__ || Object.getPrototypeOf(Localize)).call.apply(_ref, [this].concat(args))), _this), _this.render = function () {
-      var localization = _I18n2.default._localize(_this.props.value, _this.props.dateFormat ? { dateFormat: _this.props.dateFormat } : _this.props.options);
-      if (_this.props.dangerousHTML) {
-        return _react2.default.createElement('span', { style: _this.props.style, dangerouslySetInnerHTML: { __html: localization } });
+  _createClass(Localize, [{
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          value = _props.value,
+          dateFormat = _props.dateFormat,
+          _props$options = _props.options,
+          options = _props$options === undefined ? {} : _props$options,
+          dangerousHTML = _props.dangerousHTML,
+          style = _props.style,
+          className = _props.className;
+
+      var localization = _I18n2.default._localize(value, _extends({ dateFormat: dateFormat }, options));
+
+      if (dangerousHTML) {
+        return _react2.default.createElement('span', { style: style, className: className, dangerouslySetInnerHTML: { __html: localization } });
       }
       return _react2.default.createElement(
         'span',
-        { style: _this.props.style },
+        { style: style, className: className },
         localization
       );
-    }, _temp), _possibleConstructorReturn(_this, _ret);
-  }
+    }
+  }]);
 
   return Localize;
 }(_Base2.default);
@@ -60,6 +71,7 @@ Localize.propTypes = {
   options: _react2.default.PropTypes.object,
   dateFormat: _react2.default.PropTypes.string,
   dangerousHTML: _react2.default.PropTypes.bool,
+  className: _react2.default.PropTypes.string,
   /**
    * Optional styling
    */

--- a/build/lib/Translate.js
+++ b/build/lib/Translate.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -31,32 +33,39 @@ var Translate = function (_BaseComponent) {
   _inherits(Translate, _BaseComponent);
 
   function Translate() {
-    var _ref;
-
-    var _temp, _this, _ret;
-
     _classCallCheck(this, Translate);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
+    return _possibleConstructorReturn(this, (Translate.__proto__ || Object.getPrototypeOf(Translate)).apply(this, arguments));
+  }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Translate.__proto__ || Object.getPrototypeOf(Translate)).call.apply(_ref, [this].concat(args))), _this), _this.otherProps = function () {
-      var result = _extends({}, _this.props);
+  _createClass(Translate, [{
+    key: 'otherProps',
+    value: function otherProps() {
+      var result = _extends({}, this.props);
       delete result.value;
       return result;
-    }, _this.render = function () {
-      var translation = _I18n2.default._translate(_this.props.value, _this.otherProps());
-      if (_this.props.dangerousHTML) {
-        return _react2.default.createElement('span', { style: _this.props.style, dangerouslySetInnerHTML: { __html: translation } });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _props = this.props,
+          value = _props.value,
+          dangerousHTML = _props.dangerousHTML,
+          style = _props.style,
+          className = _props.className;
+
+      var translation = _I18n2.default._translate(value, this.otherProps());
+
+      if (dangerousHTML) {
+        return _react2.default.createElement('span', { style: style, className: className, dangerouslySetInnerHTML: { __html: translation } });
       }
       return _react2.default.createElement(
         'span',
-        { style: _this.props.style },
+        { style: style, className: className },
         translation
       );
-    }, _temp), _possibleConstructorReturn(_this, _ret);
-  }
+    }
+  }]);
 
   return Translate;
 }(_Base2.default);
@@ -64,6 +73,7 @@ var Translate = function (_BaseComponent) {
 Translate.propTypes = {
   value: _react2.default.PropTypes.string.isRequired,
   dangerousHTML: _react2.default.PropTypes.bool,
+  className: _react2.default.PropTypes.string,
   /**
    * Optional styling
    */

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -112,8 +112,12 @@ export default {
 
   _localize(value, options = {}) {
     if (options.dateFormat) {
-      moment.locale(this._locale);
-      return moment(value).format(this.t(options.dateFormat));
+      return moment(
+        value,
+        options.parseFormat,
+        this._locale,
+        Boolean(options.strictParse)
+      ).format(this.t(options.dateFormat));
     }
     if (typeof value === 'number') {
       if (global.Intl) {

--- a/src/lib/Localize.jsx
+++ b/src/lib/Localize.jsx
@@ -21,21 +21,18 @@ export default class Localize extends BaseComponent {
     style: React.PropTypes.objectOf(
       React.PropTypes.oneOfType([
         React.PropTypes.number,
-        React.PropTypes.string,
+        React.PropTypes.string
       ])
     ),
   };
 
-  render = () => {
-    const localization = I18n._localize(
-      this.props.value,
-      this.props.dateFormat
-        ? { dateFormat: this.props.dateFormat }
-        : this.props.options
-    );
-    if (this.props.dangerousHTML) {
-      return <span style={this.props.style} dangerouslySetInnerHTML={{ __html: localization }} />;
+  render() {
+    const { value, dateFormat, options = {}, dangerousHTML, style } = this.props;
+    const localization = I18n._localize(value, { ...options, dateFormat });
+
+    if (dangerousHTML) {
+      return <span style={style} dangerouslySetInnerHTML={{ __html: localization }} />;
     }
-    return <span style={this.props.style}>{localization}</span>;
+    return <span style={style}>{localization}</span>;
   }
 }

--- a/src/lib/Localize.jsx
+++ b/src/lib/Localize.jsx
@@ -15,6 +15,7 @@ export default class Localize extends BaseComponent {
     options: React.PropTypes.object,
     dateFormat: React.PropTypes.string,
     dangerousHTML: React.PropTypes.bool,
+    className: React.PropTypes.string,
     /**
      * Optional styling
      */
@@ -27,12 +28,12 @@ export default class Localize extends BaseComponent {
   };
 
   render() {
-    const { value, dateFormat, options = {}, dangerousHTML, style } = this.props;
+    const { value, dateFormat, options = {}, dangerousHTML, style, className } = this.props;
     const localization = I18n._localize(value, { ...options, dateFormat });
 
     if (dangerousHTML) {
-      return <span style={style} dangerouslySetInnerHTML={{ __html: localization }} />;
+      return <span style={style} className={className} dangerouslySetInnerHTML={{ __html: localization }} />;
     }
-    return <span style={style}>{localization}</span>;
+    return <span style={style} className={className}>{localization}</span>;
   }
 }

--- a/src/lib/Translate.jsx
+++ b/src/lib/Translate.jsx
@@ -15,22 +15,24 @@ export default class Translate extends BaseComponent {
     style: React.PropTypes.objectOf(
       React.PropTypes.oneOfType([
         React.PropTypes.number,
-        React.PropTypes.string,
+        React.PropTypes.string
       ])
     ),
   };
 
-  otherProps = () => {
+  otherProps() {
     const result = { ...this.props };
     delete result.value;
     return result;
   }
 
-  render = () => {
-    const translation = I18n._translate(this.props.value, this.otherProps());
-    if (this.props.dangerousHTML) {
-      return <span style={this.props.style} dangerouslySetInnerHTML={{ __html: translation }} />;
+  render() {
+    const { value, dangerousHTML, style } = this.props;
+    const translation = I18n._translate(value, this.otherProps());
+
+    if (dangerousHTML) {
+      return <span style={style} dangerouslySetInnerHTML={{ __html: translation }} />;
     }
-    return <span style={this.props.style}>{translation}</span>;
+    return <span style={style}>{translation}</span>;
   }
 }

--- a/src/lib/Translate.jsx
+++ b/src/lib/Translate.jsx
@@ -9,6 +9,7 @@ export default class Translate extends BaseComponent {
   static propTypes = {
     value: React.PropTypes.string.isRequired,
     dangerousHTML: React.PropTypes.bool,
+    className: React.PropTypes.string,
     /**
      * Optional styling
      */
@@ -27,12 +28,12 @@ export default class Translate extends BaseComponent {
   }
 
   render() {
-    const { value, dangerousHTML, style } = this.props;
+    const { value, dangerousHTML, style, className } = this.props;
     const translation = I18n._translate(value, this.otherProps());
 
     if (dangerousHTML) {
-      return <span style={style} dangerouslySetInnerHTML={{ __html: translation }} />;
+      return <span style={style} className={className} dangerouslySetInnerHTML={{ __html: translation }} />;
     }
-    return <span style={style}>{translation}</span>;
+    return <span style={style} className={className}>{translation}</span>;
   }
 }


### PR DESCRIPTION
Hi,
I'm making this PR because I think that `<Translate/>` and `<Localize/>` components could use `className` attribute to avoid some useless nested html.

BEFORE: 
```js
<span className="someclass" >
  <Translate value="not_nice"/>
</span>
```

AFTER: 
```js
<Translate className="someclass" value="nicer"/>
```

I also add parsing options to the `<Localize/>` component when non standard date are passed. 
You can use it like that:

```js
<Localize value="11/2016" 
          dateFormat="MMMM Y" 
          options={{parseFormat:'MM/YYYY', strictParse:true}}/>
```

Behavior is as follow:
- `strictParse` can be omitted and is false by default (as `moment` do).
- `parseFormat` can be omitted (`moment` will try to parse it as usual).
- if `dateFormat` is present in both component attributes and `options` attribute object, the `dateFormat` attribute is chosen => `options = { ...options, dateFormat }`

Seems to be nice to have features. 😉 