### PR TITLE
add tests for Translate and Localize component

### DIFF
--- a/__tests__/index.specs.js
+++ b/__tests__/index.specs.js
@@ -1,0 +1,13 @@
+import { I18n, Translate, Localize } from '../src';
+
+describe('index.js', () => {
+  test('should export I18n object', () => {
+    expect(I18n).toBeDefined();
+  });
+  test('should export <Translate/> component', () => {
+    expect(Translate).toBeDefined();
+  });
+  test('should export <Localize/> component', () => {
+    expect(Localize).toBeDefined();
+  });
+});

--- a/__tests__/lib/Base.specs.js
+++ b/__tests__/lib/Base.specs.js
@@ -1,0 +1,7 @@
+import Base from '../../src/lib/Base';
+
+describe('Base.jsx', () => {
+  test('should export <Base/> component', () => {
+    expect(Base).toBeDefined();
+  });
+});

--- a/__tests__/lib/Localize.specs.js
+++ b/__tests__/lib/Localize.specs.js
@@ -1,0 +1,71 @@
+import React      from 'react';
+import { mount }  from 'enzyme';
+import { I18n }   from '../../src';
+import Localize   from '../../src/lib/Localize';
+
+describe('Localize.jsx', () => {
+  test('should export <Localize/> component', () => {
+    expect(Localize).toBeDefined();
+  });
+
+  beforeAll(() => {
+    I18n.setTranslations({
+      en : {
+        date : 'MMMM Do, YYYY'
+      }
+    });
+
+    I18n.setLocale('en');
+  });
+
+  describe('<Localize/> component', () => {
+    let attrs = { value : '2016-07-04', dateFormat : 'date' }, wrapper = null;
+
+    beforeEach(() => {
+      wrapper = mount(<Localize {...attrs} />);
+    });
+
+    test('should render a <span/> with style attribute', () => {
+      const style = { fontWeight: 'bold', fontSize: '14px' };
+      wrapper.setProps({ style });
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.props().style).toBe(style);
+      expect(span.html().match(/style="([^"]*)"/i)[1]).toBe('font-weight: bold; font-size: 14px;');
+    });
+
+    test('should render a <span/> with class attribute', () => {
+      const className = 'nice';
+      wrapper.setProps({ className });
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.hasClass(className)).toBeTruthy();
+    });
+
+    test('should handle localization', () => {
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('July 4th, 2016');
+    });
+
+    test('should handle localization options', () => {
+      const props = {
+        value   : 10/3,
+        options : {
+          style                 : 'currency',
+          currency              : 'USD',
+          minimumFractionDigits : 2,
+          maximumFractionDigits : 2
+        }
+      };
+
+      const span = mount(<Localize {...props} />).find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('$3.33');
+    });
+  });
+});

--- a/__tests__/lib/Translate.specs.js
+++ b/__tests__/lib/Translate.specs.js
@@ -1,0 +1,95 @@
+import React      from 'react';
+import { mount }  from 'enzyme';
+import { I18n }   from '../../src';
+import Translate  from '../../src/lib/Translate';
+
+describe('Translate.jsx', () => {
+  test('should export <Translate/> component', () => {
+    expect(Translate).toBeDefined();
+  });
+
+  beforeAll(() => {
+    I18n.setTranslations({
+      en : {
+        application : {
+          title : 'Awesome app with i18n!',
+          hello : 'Hello, %{name}!'
+        },
+        export      : 'Export %{count} items',
+        export_0    : 'Nothing to export',
+        export_1    : 'Export %{count} item',
+        two_lines   : 'Line 1<br />Line 2'
+      }
+    });
+
+    I18n.setLocale('en');
+  });
+
+  describe('<Translate/> component', () => {
+    let attrs = { value : 'application.title' }, wrapper = null;
+
+    beforeEach(() => {
+      wrapper = mount(<Translate {...attrs} />);
+    });
+
+    test('should render a <span/> with style attribute', () => {
+      const style = { fontWeight: 'bold', fontSize: '14px' };
+      wrapper.setProps({ style });
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.props().style).toBe(style);
+      expect(span.html().match(/style="([^"]*)"/i)[1]).toBe('font-weight: bold; font-size: 14px;');
+    });
+
+    test('should render a <span/> with class attribute', () => {
+      const className = 'nice';
+      wrapper.setProps({ className });
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.hasClass(className)).toBeTruthy();
+    });
+
+    test('should handle translation', () => {
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('Awesome app with i18n!');
+    });
+
+    test('should handle dynamic placeholder', () => {
+      wrapper.setProps({ value:'application.hello', name:'Aad' });
+      const span = wrapper.find('span');
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('Hello, Aad!');
+    });
+
+    test('should handle pluralization', () => {
+      const span = wrapper.find('span');
+      wrapper.setProps({ value:'export', count:0 });
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('Nothing to export');
+
+      wrapper.setProps({ value:'export', count:1 });
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('Export 1 item');
+
+      wrapper.setProps({ value:'export', count:4 });
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('Export 4 items');
+    });
+
+    test('should handle dangerousHTML', () => {
+      const span = wrapper.find('span');
+      wrapper.setProps({ value:'two_lines' });
+
+      expect(span.type()).toBe('span');
+      expect(span.text()).toBe('Line 1<br />Line 2');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple i18n translation and localization components and helpers for React applications.",
   "main": "./build/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --colors --env=jsdom",
+    "test:watch": "npm test -- --watch",
     "lint": "esw --ext .js --ext .jsx src --color",
     "lint:watch": "npm run lint -- --watch",
     "lint:fix": "npm run lint -- --fix",
@@ -16,8 +17,12 @@
     "presets": [
       "react",
       "es2015",
-      "stage-0"
+      "stage-0",
+      "jest"
     ]
+  },
+  "jest": {
+    "verbose": true
   },
   "files": [
     "build"
@@ -48,13 +53,19 @@
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-eslint": "^7.1.1",
+    "babel-jest": "^18.0.0",
+    "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
+    "enzyme": "^2.7.1",
     "eslint": "^3.15.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-watch": "^2.1.14",
+    "jest": "^18.1.0",
+    "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-test-renderer": "^15.4.2",
     "rimraf": "^2.5.4"
   },
   "eslintConfig": {


### PR DESCRIPTION
@gerbenmeyer here are the first tests for `<Translate/>` and `<Localize/>` components. 
Tests for `I18n.js` and `formatMissingTranslation.js` have to be written too.
Feel free to add some more.

To add continuous integration (run tests on commit) you have to follow this short guide as [video](https://www.youtube.com/watch?v=OQAifaOEmVo) or [post](https://semaphoreci.com/community/tutorials/how-to-test-react-and-mobx-with-jest).  
I can't do it myself as I have no rights on this repo.

In the future, contributors will have to write tests for their features to ensure everything is working as expected and no regressions are introduced.