### PR TITLE
Remove unnecessary locales import

### DIFF
--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import 'moment/min/locales';
 import IntlPolyfill from 'intl';
 import formatMissingTranslation from './formatMissingTranslation';
 import BaseComponent from './Base';


### PR DESCRIPTION
Remove unnecessary locales import, as they come with `moment` out of the box. Having second locales import prevents from further locale optimization, in the bundles of consumers.

In our project we use webpack build exclusions (based on [this solution](http://stackoverflow.com/questions/25384360/how-to-prevent-moment-js-from-loading-locales-with-webpack)), to strip not-used locales, which works fine with plain `moment`, but not with locales minified version that is unnecessarily imported over here.