### PR TITLE
Don't use fixed versions in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   ],
   "runkitExampleFilename": "example/example.js",
   "dependencies": {
-    "intl": "1.2",
-    "moment": "2.18.1",
-    "prop-types": "15.5.8",
-    "react": "15.5.4"
+    "intl": "^1.2",
+    "moment": "^2.18.1",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",


### PR DESCRIPTION
Don't use fixed versions in dependencies to not have duplicate versions of react in a project using react != 15.5.4.
I removed 18 KB minified in my bundle with this.