### PR TITLE
[Tag] Allow rendering HTML tag to be defined as a prop

### DIFF
--- a/__tests__/lib/Localize.specs.js
+++ b/__tests__/lib/Localize.specs.js
@@ -40,6 +40,13 @@ describe('Localize.jsx', () => {
       expect(span.html().match(/style="([^"]*)"/i)[1]).toBe('font-weight: bold; font-size: 14px;');
     });
 
+    test('should render a <div/>', () => {
+      wrapper.setProps({ tag: 'div' });
+      const span = wrapper.find('div');
+
+      expect(span.type()).toBe('div');
+    });
+
     test('should render a <span/> with class attribute', () => {
       const className = 'nice';
       wrapper.setProps({ className });

--- a/__tests__/lib/Translate.specs.js
+++ b/__tests__/lib/Translate.specs.js
@@ -47,6 +47,13 @@ describe('Translate.jsx', () => {
       expect(span.html().match(/style="([^"]*)"/i)[1]).toBe('font-weight: bold; font-size: 14px;');
     });
 
+    test('should render a <div/>', () => {
+      wrapper.setProps({ tag: 'div' });
+      const span = wrapper.find('div');
+
+      expect(span.type()).toBe('div');
+    });
+
     test('should render a <span/> with class attribute', () => {
       const className = 'nice';
       wrapper.setProps({ className });

--- a/src/lib/Localize.jsx
+++ b/src/lib/Localize.jsx
@@ -5,6 +5,10 @@ import BaseComponent from './Base';
 
 export default class Localize extends BaseComponent {
   static propTypes = {
+    tag: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string
+    ]),
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
@@ -19,21 +23,25 @@ export default class Localize extends BaseComponent {
     ])),
   };
 
+  static defaultProps = {
+    tag: 'span'
+  };
+
   render() {
     const {
-      value, dateFormat, options = {}, dangerousHTML, style, className,
+      tag: Tag, value, dateFormat, options = {}, dangerousHTML, style, className,
     } = this.props;
     const localization = I18n._localize(value, { ...options, dateFormat });
 
     if (dangerousHTML) {
       return (
-        <span
+        <Tag
           style={style}
           className={className}
           dangerouslySetInnerHTML={{ __html: localization }}
         />
       );
     }
-    return <span style={style} className={className}>{localization}</span>;
+    return <Tag style={style} className={className}>{localization}</Tag>;
   }
 }

--- a/src/lib/Translate.jsx
+++ b/src/lib/Translate.jsx
@@ -5,6 +5,10 @@ import BaseComponent from './Base';
 
 export default class Translate extends BaseComponent {
   static propTypes = {
+    tag: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+    ]),
     value: PropTypes.string.isRequired,
     dangerousHTML: PropTypes.bool,
     className: PropTypes.string,
@@ -12,6 +16,10 @@ export default class Translate extends BaseComponent {
       PropTypes.number,
       PropTypes.string,
     ])),
+  };
+
+  static defaultProps = {
+    tag: 'span'
   };
 
   otherProps() {
@@ -22,19 +30,19 @@ export default class Translate extends BaseComponent {
 
   render() {
     const {
-      value, dangerousHTML, style, className,
+      tag: Tag, value, dangerousHTML, style, className,
     } = this.props;
     const translation = I18n._translate(value, this.otherProps());
 
     if (dangerousHTML) {
       return (
-        <span
+        <Tag
           style={style}
           className={className}
           dangerouslySetInnerHTML={{ __html: translation }}
         />
       );
     }
-    return <span style={style} className={className}>{translation}</span>;
+    return <Tag style={style} className={className}>{translation}</Tag>;
   }
 }


### PR DESCRIPTION
fixes #16 

The idea is to be able to choose with HTML element should be use to render the string (default to `<span/>` to preserve backward compatibility.

Example 1 (default) :

```
import { Translate } from 'react-i18nify'

return (<Translate value='key.to.translate' />)
```

Will render `<span>My translated string</span>`

Example 2 (specific tag) :

```
import { Translate } from 'react-i18nify'

return (<Translate tag='div' value='key.to.translate' />)
```

Will render `<div>My translated string</div>`

Example 3 (Component) :

```
import { Button } from 'reactstrap'
import { Translate } from 'react-i18nify'

return (<Translate tag={Button} value='key.to.translate' />)
```

Will render `<Button>My translated string</Button>`

I added tests aswell, but they do not cover the Example 3, as I was not sure how to implement that one for now.

Another use-case would be to set the tag to `null` in order to render the string only, however I couldn't figure how to pass the PropTypes validation to allow a null value...

> https://github.com/facebook/react/issues/3163

Could need your advice on this?